### PR TITLE
feat: generates checkout experience link #29 #9

### DIFF
--- a/app/src/app/auth/sign-up/SignUp.module.scss
+++ b/app/src/app/auth/sign-up/SignUp.module.scss
@@ -1,7 +1,7 @@
-@import "../../../theme/base";
+@import "src/theme/base";
 
 .sign-up {
-  display: block;
+  padding-top: $navbar-height;
 
   &__instructions {
     margin-bottom: $space-m;

--- a/app/src/app/business/BusinessDetails/InvestNowWidget/InvestNowWidget.module.scss
+++ b/app/src/app/business/BusinessDetails/InvestNowWidget/InvestNowWidget.module.scss
@@ -11,8 +11,15 @@
   }
 
   &__cta-button {
+    display: block;
+
     &--icon {
       margin-left: $space-default;
+    }
+
+    &--error {
+      margin-top: $space-default;
+      color: var(--color-status-critical);
     }
   }
 

--- a/app/src/app/business/BusinessDetails/InvestNowWidget/InvestNowWidget.module.scss.d.ts
+++ b/app/src/app/business/BusinessDetails/InvestNowWidget/InvestNowWidget.module.scss.d.ts
@@ -1,5 +1,7 @@
 export type Styles = {
   "invest-now-widget": string;
+  "invest-now-widget__cta-button": string;
+  "invest-now-widget__cta-button--error": string;
   "invest-now-widget__cta-button--icon": string;
   "invest-now-widget__cta-text": string;
   "invest-now-widget__fixed-col": string;

--- a/app/src/app/home/home/Home.module.scss
+++ b/app/src/app/home/home/Home.module.scss
@@ -1,7 +1,7 @@
-@import "../../../theme/base";
+@import "src/theme/base";
 
 .home {
-  display: block;
+  padding-top: $navbar-height;
 
   &__section {
     min-height: 70vh;

--- a/app/src/context/auth/AuthContextController.tsx
+++ b/app/src/context/auth/AuthContextController.tsx
@@ -39,7 +39,10 @@ export const AuthContextController = ({ children }: AuthContextControllerProps) 
     try {
       setIsLoading(true);
 
-      const { error } = await supabase.auth.signIn({ email });
+      const { error } = await supabase.auth.signIn(
+        { email },
+        { redirectTo: (router.query.redirectTo as string) || routes.home },
+      );
 
       if (error) {
         throw new Error(error.message);

--- a/app/src/context/checkout/CheckoutContext.ts
+++ b/app/src/context/checkout/CheckoutContext.ts
@@ -1,0 +1,5 @@
+import { createContext } from "react";
+
+import { CheckoutContextType } from "./CheckoutContext.types";
+
+export const CheckoutContext = createContext<CheckoutContextType | undefined>(undefined);

--- a/app/src/context/checkout/CheckoutContext.types.ts
+++ b/app/src/context/checkout/CheckoutContext.types.ts
@@ -1,0 +1,18 @@
+import { ReactNode } from "react";
+
+export type CheckoutContextControllerProps = {
+  children: ReactNode;
+};
+
+export type CheckoutState =
+  | {
+      url: string | undefined;
+    }
+  | undefined;
+
+export type CheckoutContextType = {
+  getCheckoutURL: () => Promise<void>;
+  checkout: CheckoutState;
+  isLoading: boolean;
+  error: string | undefined;
+};

--- a/app/src/context/checkout/CheckoutContextController.tsx
+++ b/app/src/context/checkout/CheckoutContextController.tsx
@@ -1,0 +1,63 @@
+import React, { useState } from "react";
+
+import { useAuthContext } from "hooks/useAuthContext/useAuthContext";
+
+import { CheckoutContext } from "./CheckoutContext";
+import { CheckoutContextControllerProps, CheckoutState } from "./CheckoutContext.types";
+
+export const CheckoutContextController = ({ children }: CheckoutContextControllerProps) => {
+  const [checkout, setCheckoutState] = useState<CheckoutState>(undefined);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | undefined>(undefined);
+
+  const auth = useAuthContext();
+
+  const getCheckoutURL = async () => {
+    try {
+      setIsLoading(true);
+
+      // @TODO get businessId from business mcs
+      const businessId = "6e39hBHXvVwWvJUhSb2wKoBden7Ze4zrEDmq3F3f3Gex";
+      const buyerEmail = auth.session?.user?.email;
+
+      // @TODO get store id from business mcs
+      const storeId = "6e39hBHXvVwWvJUhSb2wKoBden7Ze4zrEDmq3F3f3Gex";
+
+      const metadata = { businessId, buyerEmail };
+
+      const response = await fetch(`/api/getCheckoutURL`, {
+        method: "POST",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ metadata, storeId }),
+      });
+
+      const content = await response.json();
+
+      if (!content?.checkoutLink) {
+        throw new Error("Invalid BTC checkout content at CheckoutContextController:getCheckoutURL");
+      }
+
+      setCheckoutState({
+        url: content.checkoutLink,
+      });
+
+      setIsLoading(false);
+    } catch (error_) {
+      // @TODO handle error
+      console.error(error_);
+      setError(
+        "Error at CheckoutContextController:getCheckoutURL. Check server logs as this may have happened in the API side.",
+      );
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <CheckoutContext.Provider value={{ getCheckoutURL, checkout, isLoading, error }}>
+      {children}
+    </CheckoutContext.Provider>
+  );
+};

--- a/app/src/hooks/useCheckoutContext/useCheckoutContext.test.tsx
+++ b/app/src/hooks/useCheckoutContext/useCheckoutContext.test.tsx
@@ -1,0 +1,11 @@
+import { renderHook } from 'tests';
+
+import { useCheckoutContext } from './useCheckoutContext';
+
+describe('useCheckoutContext', () => {
+  it('returns a value', async () => {
+    const { result } = renderHook(() => useCheckoutContext());
+
+    expect(result.current).toEqual('1');
+  });
+});

--- a/app/src/hooks/useCheckoutContext/useCheckoutContext.tsx
+++ b/app/src/hooks/useCheckoutContext/useCheckoutContext.tsx
@@ -1,0 +1,13 @@
+import { useContext } from "react";
+
+import { CheckoutContext } from "context/checkout/CheckoutContext";
+
+export const useCheckoutContext = () => {
+  const context = useContext(CheckoutContext);
+
+  if (context === undefined) {
+    throw new Error("useCheckoutContext must be used within a TabContext");
+  }
+
+  return context;
+};

--- a/app/src/pages/api/getCheckoutURL.ts
+++ b/app/src/pages/api/getCheckoutURL.ts
@@ -1,0 +1,35 @@
+// Next.js API route support: https://nextjs.org/docs/api-routes/introduction
+
+import { NextApiRequest, NextApiResponse } from "next";
+
+export default async (req: NextApiRequest, res: NextApiResponse) => {
+  try {
+    const metadata = { businessId: req.body.metadata.businessId, buyerEmail: req.body.metadata.buyerEmail };
+    const { storeId } = req.body;
+    const endpoint = `${process.env.BTC_PAY_SERVER_BASE_URL}/stores/${storeId}/invoices`;
+    const headers = {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      Authorization: `token ${process.env.BTC_PAY_SERVER_AUTH_TOKEN}`,
+    };
+
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ metadata }),
+    });
+
+    const content = await response.json();
+
+    if (!content?.checkoutLink) {
+      throw new Error("Invalid BTC checkout content at API:getCheckoutURL");
+    }
+
+    res.status(200).json({
+      checkoutLink: content.checkoutLink,
+    });
+  } catch (error) {
+    console.log(error);
+    res.status(500);
+  }
+};

--- a/app/src/pages/api/hello.js
+++ b/app/src/pages/api/hello.js
@@ -1,5 +1,0 @@
-// Next.js API route support: https://nextjs.org/docs/api-routes/introduction
-
-export default (req, res) => {
-  res.status(200).json({ name: "John Doe" });
-};

--- a/app/src/pages/b/[businessId].tsx
+++ b/app/src/pages/b/[businessId].tsx
@@ -5,11 +5,14 @@ import { BusinessDetailsContainer } from "app/business/BusinessDetails/BusinessD
 import { AppLayout } from "layouts/app-layout/AppLayout";
 import { AuthLayout } from "layouts/auth-layout/AuthLayout";
 import { BusinessDetailsProps } from "app/business/BusinessDetails/BusinessDetails.types";
+import { CheckoutContextController } from "context/checkout/CheckoutContextController";
 
 const Index: NextPage<BusinessDetailsProps> = ({ content }) => (
   <AppLayout>
     <AuthLayout>
-      <BusinessDetailsContainer content={content} />
+      <CheckoutContextController>
+        <BusinessDetailsContainer content={content} />
+      </CheckoutContextController>
     </AuthLayout>
   </AppLayout>
 );


### PR DESCRIPTION
Gets a BTC Pay URL from the Checkout API.
NOTE: This happens on the API server side to prevent sharing the AUTH TOKEN.

The Client calls the App API, not the BTC API directly.

If the user is not logged in, then redirect to Auth.
Once signed-in, the user should be redirected to the business page and be able to click the Deposit button again, this time, generating a URL to checkout: 

<img width="1440" alt="Screen Shot 2021-11-16 at 19 47 57" src="https://user-images.githubusercontent.com/90481788/142095114-38d2ab44-0fcb-499a-9b02-98e3f557d8ee.png">